### PR TITLE
:bug: Accept the tabs as token separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Accept the tabs as token seprator in the input.
 
 ## [0.1.0] - 2022-07-02
 ### Added

--- a/frontend/src/libs/text-parser.js
+++ b/frontend/src/libs/text-parser.js
@@ -2,7 +2,7 @@ export function parseText(text) {
     const lines = text
         .split("\n")
         .filter((x) => x)
-        .map((line) => line.split(" ").filter((x) => x));
+        .map((line) => line.split(/\s+/).filter((x) => x));
     let found = lines.find((tokens) => tokens.length > 5);
     if (found) {
         throw `A line has too much tokens '${found}'`;


### PR DESCRIPTION
The `arm-none-eabi-nm` seems to use this separator before the file path.