### PR TITLE
:lipstick: Fix the size of the table to 40em

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Fix the size of the table to 40em.
+
 ### Fixed
 - Resolve paths with .. in it.
 - Count weak symboles in the rom size.

--- a/frontend/src/components/TreeTable.svelte
+++ b/frontend/src/components/TreeTable.svelte
@@ -39,7 +39,7 @@
 <style>
     .wrapper {
         overflow: scroll;
-        max-height: 40em;
+        height: 40em;
     }
 
     table {


### PR DESCRIPTION
This is to remove the scrollbar which can be shown even if the table is empty on some browsers.